### PR TITLE
Time based optimizations

### DIFF
--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/ActionRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/ActionRequest.java
@@ -16,6 +16,10 @@
 package com.flipkart.foxtrot.common;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.flipkart.foxtrot.common.query.Filter;
+import com.flipkart.foxtrot.common.query.numeric.LessThanFilter;
+
+import java.util.List;
 
 /**
  * User: Santanu Sinha (santanu.sinha@flipkart.com)
@@ -23,5 +27,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * Time: 7:49 PM
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "opcode")
-public interface ActionRequest {
+public abstract class ActionRequest {
+    private List<Filter> filters;
+
+    public List<Filter> getFilters() {
+        return filters;
+    }
+
+    public void setFilters(List<Filter> filters) {
+        this.filters = filters;
+    }
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/count/CountRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/count/CountRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Created by rishabh.goyal on 02/11/14.
  */
-public class CountRequest implements ActionRequest {
+public class CountRequest extends ActionRequest {
 
     @NotNull
     @NotEmpty
@@ -22,15 +22,6 @@ public class CountRequest implements ActionRequest {
 
     private boolean isDistinct = false;
 
-    private List<Filter> filters;
-
-    @Min(0)
-    @Max(Long.MAX_VALUE)
-    private long from = 0L;
-
-    @Min(0)
-    @Max(Long.MAX_VALUE)
-    private long to = 0L;
 
     public CountRequest() {
     }
@@ -59,39 +50,13 @@ public class CountRequest implements ActionRequest {
         this.isDistinct = isDistinct;
     }
 
-    public List<Filter> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
-    }
-
-    public long getFrom() {
-        return from;
-    }
-
-    public void setFrom(long from) {
-        this.from = from;
-    }
-
-    public long getTo() {
-        return to;
-    }
-
-    public void setTo(long to) {
-        this.to = to;
-    }
-
     @Override
     public String toString() {
         return "CountRequest{" +
                 "table='" + table + '\'' +
                 ", field='" + field + '\'' +
                 ", isDistinct=" + isDistinct +
-                ", filters=" + filters +
-                ", from=" + from +
-                ", to=" + to +
+                ", filters=" + getFilters() +
                 '}';
     }
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/distinct/DistinctRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/distinct/DistinctRequest.java
@@ -29,12 +29,10 @@ import java.util.List;
  * Date: 21/03/14
  * Time: 4:52 PM
  */
-public class DistinctRequest implements ActionRequest {
+public class DistinctRequest extends ActionRequest {
     @NotNull
     @NotEmpty
     private String table;
-
-    private List<Filter> filters;
 
     @NotNull
     @NotEmpty
@@ -51,13 +49,6 @@ public class DistinctRequest implements ActionRequest {
         this.table = table;
     }
 
-    public List<Filter> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
-    }
 
     public List<ResultSort> getNesting() {
         return nesting;
@@ -71,7 +62,7 @@ public class DistinctRequest implements ActionRequest {
     public String toString() {
         return new ToStringBuilder(this)
                 .append("table", table)
-                .append("filters", filters)
+                .append("filters", getFilters())
                 .append("nesting", nesting)
                 .toString();
     }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/group/GroupRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/group/GroupRequest.java
@@ -28,12 +28,11 @@ import java.util.List;
  * Date: 21/03/14
  * Time: 4:52 PM
  */
-public class GroupRequest implements ActionRequest {
+public class GroupRequest extends ActionRequest {
     @NotNull
     @NotEmpty
     private String table;
 
-    private List<Filter> filters;
 
     @NotNull
     @NotEmpty
@@ -50,13 +49,6 @@ public class GroupRequest implements ActionRequest {
         this.table = table;
     }
 
-    public List<Filter> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
-    }
 
     public List<String> getNesting() {
         return nesting;
@@ -70,7 +62,7 @@ public class GroupRequest implements ActionRequest {
     public String toString() {
         return new ToStringBuilder(this)
                 .append("table", table)
-                .append("filters", filters)
+                .append("filters", getFilters())
                 .append("nesting", nesting)
                 .toString();
     }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/histogram/HistogramRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/histogram/HistogramRequest.java
@@ -30,16 +30,11 @@ import java.util.List;
  * Date: 21/03/14
  * Time: 12:06 AM
  */
-public class HistogramRequest implements ActionRequest {
+public class HistogramRequest extends ActionRequest {
     @NotNull
     @NotEmpty
     private String table;
 
-    private List<Filter> filters;
-    @Min(0)
-    private long from;
-    @Min(0)
-    private long to;
 
     @NotNull
     @NotEmpty
@@ -48,9 +43,6 @@ public class HistogramRequest implements ActionRequest {
     private Period period;
 
     public HistogramRequest() {
-        long timestamp = System.currentTimeMillis();
-        this.from = timestamp - 86400000;
-        this.to = timestamp;
         this.field = "_timestamp";
         this.period = Period.minutes;
     }
@@ -61,30 +53,6 @@ public class HistogramRequest implements ActionRequest {
 
     public void setTable(String table) {
         this.table = table;
-    }
-
-    public List<Filter> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
-    }
-
-    public long getFrom() {
-        return from;
-    }
-
-    public void setFrom(long from) {
-        this.from = from;
-    }
-
-    public long getTo() {
-        return to;
-    }
-
-    public void setTo(long to) {
-        this.to = to;
     }
 
     public Period getPeriod() {
@@ -99,19 +67,18 @@ public class HistogramRequest implements ActionRequest {
         return field;
     }
 
+    public void setField(String field) {
+        this.field = field;
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .append("table", table)
-                .append("filters", filters)
-                .append("from", from)
-                .append("to", to)
+                .append("filters", getFilters())
                 .append("field", field)
                 .append("period", period)
                 .toString();
     }
 
-    public void setField(String field) {
-        this.field = field;
-    }
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/histogram/HistogramResponse.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/histogram/HistogramResponse.java
@@ -90,9 +90,7 @@ public class HistogramResponse implements ActionResponse {
     public HistogramResponse() {
     }
 
-    public HistogramResponse(long from, long to, List<Count> counts) {
-        this.from = from;
-        this.to = to;
+    public HistogramResponse(List<Count> counts) {
         this.counts = counts;
     }
 

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/Filter.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/Filter.java
@@ -116,4 +116,9 @@ public abstract class Filter {
                 .append("field", field)
                 .toString();
     }
+
+    public boolean isTemporal() {
+        return false;
+    }
+
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/Query.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/Query.java
@@ -27,15 +27,9 @@ import java.util.List;
  * Date: 13/03/14
  * Time: 6:38 PM
  */
-public class Query implements ActionRequest {
+public class Query extends ActionRequest {
     @NotNull
     private String table;
-
-    @NotNull
-    private List<Filter> filters;
-
-    @NotNull
-    private FilterCombinerType combiner = FilterCombinerType.and;
 
     private ResultSort sort;
 
@@ -57,14 +51,6 @@ public class Query implements ActionRequest {
 
     public void setTable(String table) {
         this.table = table;
-    }
-
-    public List<Filter> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
     }
 
     public ResultSort getSort() {
@@ -91,20 +77,11 @@ public class Query implements ActionRequest {
         this.limit = limit;
     }
 
-    public FilterCombinerType getCombiner() {
-        return combiner;
-    }
-
-    public void setCombiner(FilterCombinerType combiner) {
-        this.combiner = combiner;
-    }
-
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .append("table", table)
-                .append("filters", filters)
-                .append("combiner", combiner)
+                .append("filters", getFilters())
                 .append("sort", sort)
                 .append("from", from)
                 .append("limit", limit)

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/datetime/LastFilter.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/datetime/LastFilter.java
@@ -73,4 +73,9 @@ public class LastFilter extends Filter {
                 ", duration=" + duration +
                 '}';
     }
+
+    @Override
+    public boolean isTemporal() {
+        return true;
+    }
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/datetime/TimeWindow.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/datetime/TimeWindow.java
@@ -1,5 +1,7 @@
 package com.flipkart.foxtrot.common.query.datetime;
 
+import java.util.Date;
+
 public class TimeWindow {
     private long startTime;
     private long endTime;
@@ -53,8 +55,8 @@ public class TimeWindow {
     @Override
     public String toString() {
         return "TimeWindow{" +
-                "startTime=" + startTime +
-                ", endTime=" + endTime +
+                "startTime=" + new Date(startTime).toString() +
+                ", endTime=" + new Date(endTime).toString() +
                 '}';
     }
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/numeric/BetweenFilter.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/numeric/BetweenFilter.java
@@ -97,6 +97,7 @@ public class BetweenFilter extends Filter {
                 .toString();
     }
 
+    @Override
     public boolean isTemporal() {
         return temporal;
     }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/numeric/NumericBinaryFilter.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/query/numeric/NumericBinaryFilter.java
@@ -66,6 +66,7 @@ public abstract class NumericBinaryFilter extends Filter {
         return result;
     }
 
+    @Override
     public boolean isTemporal() {
         return temporal;
     }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/stats/StatsRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/stats/StatsRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * Created by rishabh.goyal on 02/08/14.
  */
-public class StatsRequest implements ActionRequest {
+public class StatsRequest extends ActionRequest {
 
     @NotNull
     @NotEmpty
@@ -21,9 +21,6 @@ public class StatsRequest implements ActionRequest {
     @NotNull
     @NotEmpty
     private String field;
-
-    @NotNull
-    private List<Filter> filters;
 
     @NotNull
     private FilterCombinerType combiner = FilterCombinerType.and;
@@ -48,14 +45,6 @@ public class StatsRequest implements ActionRequest {
         this.field = field;
     }
 
-    public List<Filter> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
-    }
-
     public FilterCombinerType getCombiner() {
         return combiner;
     }
@@ -69,7 +58,7 @@ public class StatsRequest implements ActionRequest {
         return new ToStringBuilder(this)
                 .append("table", table)
                 .append("field", field)
-                .append("filters", filters)
+                .append("filters", getFilters())
                 .append("combiner", combiner)
                 .toString();
     }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/stats/StatsTrendRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/stats/StatsTrendRequest.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Created by rishabh.goyal on 02/08/14.
  */
-public class StatsTrendRequest implements ActionRequest {
+public class StatsTrendRequest extends ActionRequest {
     @NotNull
     @NotEmpty
     private String table;
@@ -24,23 +24,12 @@ public class StatsTrendRequest implements ActionRequest {
     private String field;
 
     @NotNull
-    private List<Filter> filters;
-
-    @NotNull
     private FilterCombinerType combiner = FilterCombinerType.and;
 
     @NotNull
     private Period period = Period.hours;
 
     private String timestamp = "_timestamp";
-
-    @Min(0)
-    @Max(Long.MAX_VALUE)
-    private long from = 0L;
-
-    @Min(0)
-    @Max(Long.MAX_VALUE)
-    private long to = 0L;
 
     public StatsTrendRequest() {
 
@@ -60,14 +49,6 @@ public class StatsTrendRequest implements ActionRequest {
 
     public void setField(String field) {
         this.field = field;
-    }
-
-    public List<Filter> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
     }
 
     public FilterCombinerType getCombiner() {
@@ -94,33 +75,15 @@ public class StatsTrendRequest implements ActionRequest {
         this.timestamp = timestamp;
     }
 
-    public long getFrom() {
-        return from;
-    }
-
-    public void setFrom(long from) {
-        this.from = from;
-    }
-
-    public long getTo() {
-        return to;
-    }
-
-    public void setTo(long to) {
-        this.to = to;
-    }
-
     @Override
     public String toString() {
         return "StatsTrendRequest{" +
                 "table='" + table + '\'' +
                 ", field='" + field + '\'' +
-                ", filters=" + filters +
+                ", filters=" + getFilters() +
                 ", combiner=" + combiner +
                 ", period=" + period +
                 ", timestamp='" + timestamp + '\'' +
-                ", from=" + from +
-                ", to=" + to +
                 '}';
     }
 }

--- a/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/trend/TrendRequest.java
+++ b/foxtrot-common/src/main/java/com/flipkart/foxtrot/common/trend/TrendRequest.java
@@ -31,7 +31,7 @@ import java.util.List;
  * Date: 30/03/14
  * Time: 2:30 PM
  */
-public class TrendRequest implements ActionRequest {
+public class TrendRequest extends ActionRequest {
     @NotNull
     @NotEmpty
     private String table;
@@ -40,21 +40,11 @@ public class TrendRequest implements ActionRequest {
     @NotEmpty
     private String field;
 
-    private List<Filter> filters;
-
     private String timestamp = "_timestamp";
 
     private Period period = Period.days;
 
     private List<String> values;
-
-    @Min(0)
-    @Max(Long.MAX_VALUE)
-    private long from = 0L;
-
-    @Min(0)
-    @Max(Long.MAX_VALUE)
-    private long to = 0L;
 
     public TrendRequest() {
     }
@@ -65,14 +55,6 @@ public class TrendRequest implements ActionRequest {
 
     public void setTable(String table) {
         this.table = table;
-    }
-
-    public List<Filter> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(List<Filter> filters) {
-        this.filters = filters;
     }
 
     public String getField() {
@@ -99,31 +81,13 @@ public class TrendRequest implements ActionRequest {
         this.values = values;
     }
 
-    public long getFrom() {
-        return from;
-    }
-
-    public void setFrom(long from) {
-        this.from = from;
-    }
-
-    public long getTo() {
-        return to;
-    }
-
-    public void setTo(long to) {
-        this.to = to;
-    }
-
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .append("table", table)
-                .append("filters", filters)
+                .append("filters", getFilters())
                 .append("field", field)
                 .append("values", values)
-                .append("from", from)
-                .append("to", to)
                 .toString();
     }
 

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/Action.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/Action.java
@@ -18,18 +18,27 @@ package com.flipkart.foxtrot.core.common;
 import com.flipkart.foxtrot.common.ActionRequest;
 import com.flipkart.foxtrot.common.ActionResponse;
 import com.flipkart.foxtrot.common.query.Filter;
+import com.flipkart.foxtrot.common.query.FilterVisitor;
 import com.flipkart.foxtrot.common.query.datetime.LastFilter;
-import com.flipkart.foxtrot.common.query.numeric.LessThanFilter;
+import com.flipkart.foxtrot.common.query.datetime.TimeWindow;
+import com.flipkart.foxtrot.common.query.general.*;
+import com.flipkart.foxtrot.common.query.numeric.*;
+import com.flipkart.foxtrot.common.query.string.ContainsFilter;
 import com.flipkart.foxtrot.core.datastore.DataStore;
 import com.flipkart.foxtrot.core.querystore.QueryStore;
 import com.flipkart.foxtrot.core.querystore.QueryStoreException;
 import com.flipkart.foxtrot.core.querystore.TableMetadataManager;
 import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchConnection;
+import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchUtils;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
-import com.yammer.dropwizard.util.Duration;
+import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -164,6 +173,5 @@ public abstract class Action<ParameterType extends ActionRequest> implements Cal
         filters.add(getDefaultTimeSpan());
         return filters;
     }
-
 
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/PeriodSelector.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/PeriodSelector.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2014 Flipkart Internet Pvt. Ltd.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipkart.foxtrot.core.common;
+
+import com.flipkart.foxtrot.common.query.Filter;
+import com.flipkart.foxtrot.common.query.FilterVisitor;
+import com.flipkart.foxtrot.common.query.datetime.LastFilter;
+import com.flipkart.foxtrot.common.query.datetime.TimeWindow;
+import com.flipkart.foxtrot.common.query.general.*;
+import com.flipkart.foxtrot.common.query.numeric.*;
+import com.flipkart.foxtrot.common.query.string.ContainsFilter;
+import org.joda.time.Interval;
+
+import java.util.List;
+
+public class PeriodSelector extends FilterVisitor {
+
+    private final TimeWindow timeWindow = new TimeWindow();
+    private final List<Filter> filters;
+
+    public PeriodSelector(final List<Filter> filters) {
+        this.filters = filters;
+        timeWindow.setStartTime(Long.MAX_VALUE);
+        timeWindow.setEndTime(Long.MIN_VALUE);
+    }
+
+    public Interval analyze() throws Exception {
+        for(Filter filter : filters) {
+            if(filter.isTemporal()) {
+                filter.accept(this);
+            }
+        }
+        timeWindow.setStartTime(timeWindow.getStartTime() == Long.MAX_VALUE ? 0 : timeWindow.getStartTime());
+        timeWindow.setEndTime(timeWindow.getEndTime() == Long.MIN_VALUE ? System.currentTimeMillis() : timeWindow.getEndTime());
+        return new Interval(timeWindow.getStartTime(), timeWindow.getEndTime());
+    }
+
+    @Override
+    public void visit(BetweenFilter betweenFilter) throws Exception {
+        timeWindow.setStartTime(Math.min((Long) betweenFilter.getFrom(), timeWindow.getStartTime()));
+        timeWindow.setEndTime(Math.max((Long) betweenFilter.getTo(), timeWindow.getEndTime()));
+    }
+
+    @Override
+    public void visit(EqualsFilter equalsFilter) throws Exception {
+        timeWindow.setStartTime((Long) equalsFilter.getValue());
+        timeWindow.setEndTime((Long) equalsFilter.getValue());
+    }
+
+    @Override
+    public void visit(NotEqualsFilter notEqualsFilter) throws Exception {
+    }
+
+    @Override
+    public void visit(ContainsFilter stringContainsFilterElement) throws Exception {
+    }
+
+    @Override
+    public void visit(GreaterThanFilter greaterThanFilter) throws Exception {
+        timeWindow.setStartTime(Math.min((Long) greaterThanFilter.getValue() + 1, timeWindow.getStartTime()));
+    }
+
+    @Override
+    public void visit(GreaterEqualFilter greaterEqualFilter) throws Exception {
+        timeWindow.setStartTime(Math.min((Long) greaterEqualFilter.getValue(), timeWindow.getStartTime()));
+    }
+
+    @Override
+    public void visit(LessThanFilter lessThanFilter) throws Exception {
+        timeWindow.setEndTime(Math.max((Long) lessThanFilter.getValue() - 1, timeWindow.getEndTime()));
+    }
+
+    @Override
+    public void visit(LessEqualFilter lessEqualFilter) throws Exception {
+        timeWindow.setEndTime(Math.max((Long) lessEqualFilter.getValue(), timeWindow.getEndTime()));
+    }
+
+    @Override
+    public void visit(AnyFilter anyFilter) throws Exception {
+
+    }
+
+    @Override
+    public void visit(InFilter inFilter) throws Exception {
+
+    }
+
+    @Override
+    public void visit(ExistsFilter existsFilter) throws Exception {
+
+    }
+
+    @Override
+    public void visit(LastFilter lastFilter) throws Exception {
+        TimeWindow window = lastFilter.getWindow();
+        timeWindow.setStartTime(window.getStartTime());
+        timeWindow.setEndTime(window.getEndTime());
+    }
+}

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/PeriodSelector.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/common/PeriodSelector.java
@@ -23,6 +23,7 @@ import com.flipkart.foxtrot.common.query.datetime.TimeWindow;
 import com.flipkart.foxtrot.common.query.general.*;
 import com.flipkart.foxtrot.common.query.numeric.*;
 import com.flipkart.foxtrot.common.query.string.ContainsFilter;
+import com.google.common.annotations.VisibleForTesting;
 import org.joda.time.Interval;
 
 import java.util.List;
@@ -39,13 +40,17 @@ public class PeriodSelector extends FilterVisitor {
     }
 
     public Interval analyze() throws Exception {
+        return analyze(System.currentTimeMillis());
+    }
+
+    public Interval analyze(long currentTime) throws Exception {
         for(Filter filter : filters) {
             if(filter.isTemporal()) {
                 filter.accept(this);
             }
         }
         timeWindow.setStartTime(timeWindow.getStartTime() == Long.MAX_VALUE ? 0 : timeWindow.getStartTime());
-        timeWindow.setEndTime(timeWindow.getEndTime() == Long.MIN_VALUE ? System.currentTimeMillis() : timeWindow.getEndTime());
+        timeWindow.setEndTime(timeWindow.getEndTime() == Long.MIN_VALUE ? currentTime : timeWindow.getEndTime());
         return new Interval(timeWindow.getStartTime(), timeWindow.getEndTime());
     }
 
@@ -57,8 +62,6 @@ public class PeriodSelector extends FilterVisitor {
 
     @Override
     public void visit(EqualsFilter equalsFilter) throws Exception {
-        timeWindow.setStartTime((Long) equalsFilter.getValue());
-        timeWindow.setEndTime((Long) equalsFilter.getValue());
     }
 
     @Override

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/CountAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/CountAction.java
@@ -77,7 +77,7 @@ public class CountAction extends Action<CountRequest> {
         try {
             if (parameter.isDistinct()){
                 SearchRequestBuilder query = getConnection().getClient()
-                        .prepareSearch(ElasticsearchUtils.getIndices(parameter.getTable()))
+                        .prepareSearch(ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
                         .setSearchType(SearchType.COUNT)
                         .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and)
                                 .genFilter(parameter.getFilters()))
@@ -95,7 +95,7 @@ public class CountAction extends Action<CountRequest> {
                 }
             } else {
                 CountRequestBuilder countRequestBuilder = getConnection().getClient()
-                        .prepareCount(ElasticsearchUtils.getIndices(parameter.getTable()))
+                        .prepareCount(ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
                         .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and).genFilter(parameter.getFilters()));
                 org.elasticsearch.action.count.CountResponse countResponse = countRequestBuilder.execute().actionGet();
                 return new CountResponse(countResponse.getCount());

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/DistinctAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/DistinctAction.java
@@ -72,7 +72,7 @@ public class DistinctAction extends Action<DistinctRequest> {
         }
         try {
             SearchRequestBuilder query = getConnection().getClient().prepareSearch(ElasticsearchUtils.getIndices(
-                    request.getTable()));
+                    request.getTable(), request));
             TermsBuilder rootBuilder = null;
             TermsBuilder termsBuilder = null;
 

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/FilterAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/FilterAction.java
@@ -16,10 +16,7 @@
 package com.flipkart.foxtrot.core.querystore.actions;
 
 import com.flipkart.foxtrot.common.Document;
-import com.flipkart.foxtrot.common.query.Filter;
-import com.flipkart.foxtrot.common.query.Query;
-import com.flipkart.foxtrot.common.query.QueryResponse;
-import com.flipkart.foxtrot.common.query.ResultSort;
+import com.flipkart.foxtrot.common.query.*;
 import com.flipkart.foxtrot.common.query.general.AnyFilter;
 import com.flipkart.foxtrot.core.common.Action;
 import com.flipkart.foxtrot.core.datastore.DataStore;
@@ -69,7 +66,6 @@ public class FilterAction extends Action<Query> {
                 filterHashKey += 31 * filter.hashCode();
             }
         }
-        filterHashKey += 31 * (query.getCombiner() != null ? query.getCombiner().name().hashCode() : "COMBINER".hashCode());
         filterHashKey += 31 * (query.getSort() != null ? query.getSort().hashCode() : "SORT".hashCode());
 
         return String.format("%s-%d-%d-%d", query.getTable(),
@@ -97,7 +93,7 @@ public class FilterAction extends Action<Query> {
             }*/
             search = getConnection().getClient().prepareSearch(ElasticsearchUtils.getIndices(parameter.getTable()))
                     .setTypes(ElasticsearchUtils.TYPE_NAME)
-                    .setQuery(new ElasticSearchQueryGenerator(parameter.getCombiner()).genFilter(parameter.getFilters()))
+                    .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and).genFilter(parameter.getFilters()))
                     .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
                     .setFrom(parameter.getFrom())
                     .setSize(parameter.getLimit());

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/FilterAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/FilterAction.java
@@ -91,7 +91,7 @@ public class FilterAction extends Action<Query> {
                 throw new QueryStoreException(QueryStoreException.ErrorCode.NO_SUCH_TABLE,
                         "There is no table called: " + query.getTable());
             }*/
-            search = getConnection().getClient().prepareSearch(ElasticsearchUtils.getIndices(parameter.getTable()))
+            search = getConnection().getClient().prepareSearch(ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
                     .setTypes(ElasticsearchUtils.TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and).genFilter(parameter.getFilters()))
                     .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/GroupAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/GroupAction.java
@@ -87,7 +87,7 @@ public class GroupAction extends Action<GroupRequest> {
         }
         try {
             SearchRequestBuilder query = getConnection().getClient().prepareSearch(ElasticsearchUtils.getIndices(
-                    parameter.getTable()));
+                    parameter.getTable(), parameter));
             TermsBuilder rootBuilder = null;
             TermsBuilder termsBuilder = null;
             for (String field : parameter.getNesting()) {

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/HistogramAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/HistogramAction.java
@@ -114,7 +114,7 @@ public class HistogramAction extends Action<HistogramRequest> {
 
             String dateHistogramKey = Utils.sanitizeFieldForAggregation(parameter.getField());
             SearchResponse response = getConnection().getClient().prepareSearch(
-                    ElasticsearchUtils.getIndices(parameter.getTable()))
+                    ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
                     .setTypes(ElasticsearchUtils.TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and)
                             .genFilter(parameter.getFilters()))

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/HistogramAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/HistogramAction.java
@@ -20,6 +20,7 @@ import com.flipkart.foxtrot.common.histogram.HistogramRequest;
 import com.flipkart.foxtrot.common.histogram.HistogramResponse;
 import com.flipkart.foxtrot.common.query.Filter;
 import com.flipkart.foxtrot.common.query.FilterCombinerType;
+import com.flipkart.foxtrot.common.query.datetime.LastFilter;
 import com.flipkart.foxtrot.common.query.general.AnyFilter;
 import com.flipkart.foxtrot.core.common.Action;
 import com.flipkart.foxtrot.core.datastore.DataStore;
@@ -31,6 +32,7 @@ import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchConnection;
 import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchUtils;
 import com.flipkart.foxtrot.core.querystore.query.ElasticSearchQueryGenerator;
 import com.google.common.collect.Lists;
+import com.yammer.dropwizard.util.Duration;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -74,9 +76,8 @@ public class HistogramAction extends Action<HistogramRequest> {
             }
         }
 
-        return String.format("%s-%d-%d-%d-%s-%s", query.getTable(),
-                query.getFrom() / 30000, query.getTo() / 30000,
-                filterHashKey, query.getPeriod().name(), query.getField());
+        return String.format("%s-%s-%s-%d", query.getTable(),
+                query.getPeriod().name(), query.getField(), filterHashKey);
     }
 
     @Override
@@ -116,11 +117,7 @@ public class HistogramAction extends Action<HistogramRequest> {
                     ElasticsearchUtils.getIndices(parameter.getTable()))
                     .setTypes(ElasticsearchUtils.TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and)
-                            .genFilter(parameter.getFilters())
-                            .must(QueryBuilders.rangeQuery(parameter.getField())
-                                    .from(parameter.getFrom())
-                                    .to(parameter.getTo()))
-                    )
+                            .genFilter(parameter.getFilters()))
                     .setSize(0)
                     .setSearchType(SearchType.COUNT)
                     .addAggregation(AggregationBuilders.dateHistogram(dateHistogramKey)
@@ -131,7 +128,7 @@ public class HistogramAction extends Action<HistogramRequest> {
             Aggregations aggregations = response.getAggregations();
             if (aggregations == null) {
                 logger.error("Null response for Histogram. Request : " + parameter.toString());
-                return new HistogramResponse(parameter.getFrom(), parameter.getTo(), Collections.<HistogramResponse.Count>emptyList());
+                return new HistogramResponse(Collections.<HistogramResponse.Count>emptyList());
             }
             DateHistogram dateHistogram = aggregations.get(dateHistogramKey);
             Collection<? extends DateHistogram.Bucket> buckets = dateHistogram.getBuckets();
@@ -141,7 +138,7 @@ public class HistogramAction extends Action<HistogramRequest> {
                         bucket.getKeyAsNumber(), bucket.getDocCount());
                 counts.add(count);
             }
-            return new HistogramResponse(parameter.getFrom(), parameter.getTo(), counts);
+            return new HistogramResponse(counts);
         } catch (QueryStoreException ex) {
             throw ex;
         } catch (Exception e) {
@@ -149,4 +146,13 @@ public class HistogramAction extends Action<HistogramRequest> {
                     "Malformed query", e);
         }
     }
+
+    @Override
+    protected Filter getDefaultTimeSpan() {
+        LastFilter lastFilter = new LastFilter();
+        lastFilter.setField("_timestamp");
+        lastFilter.setDuration(Duration.days(1));
+        return lastFilter;
+    }
+
 }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsAction.java
@@ -71,7 +71,7 @@ public class StatsAction extends Action<StatsRequest> {
 
         try {
             SearchResponse response = getConnection().getClient().prepareSearch(
-                    ElasticsearchUtils.getIndices(request.getTable()))
+                    ElasticsearchUtils.getIndices(request.getTable(), request))
                     .setTypes(ElasticsearchUtils.TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(request.getCombiner()).genFilter(request.getFilters()))
                     .setSize(0)

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsTrendAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsTrendAction.java
@@ -84,7 +84,7 @@ public class StatsTrendAction extends Action<StatsTrendRequest> {
         try {
             AbstractAggregationBuilder aggregation = buildAggregation(parameter);
             SearchResponse response = getConnection().getClient().prepareSearch(
-                    ElasticsearchUtils.getIndices(parameter.getTable()))
+                    ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
                     .setTypes(ElasticsearchUtils.TYPE_NAME)
                     .setQuery(new ElasticSearchQueryGenerator(parameter.getCombiner()).genFilter(parameter.getFilters()))
                     .setSize(0)

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsTrendAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/StatsTrendAction.java
@@ -2,6 +2,7 @@ package com.flipkart.foxtrot.core.querystore.actions;
 
 import com.flipkart.foxtrot.common.ActionResponse;
 import com.flipkart.foxtrot.common.query.Filter;
+import com.flipkart.foxtrot.common.query.datetime.LastFilter;
 import com.flipkart.foxtrot.common.query.general.AnyFilter;
 import com.flipkart.foxtrot.common.stats.StatsTrendRequest;
 import com.flipkart.foxtrot.common.stats.StatsTrendResponse;
@@ -16,6 +17,7 @@ import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchConnection;
 import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchUtils;
 import com.flipkart.foxtrot.core.querystore.query.ElasticSearchQueryGenerator;
 import com.google.common.collect.Lists;
+import com.yammer.dropwizard.util.Duration;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
@@ -60,8 +62,8 @@ public class StatsTrendAction extends Action<StatsTrendRequest> {
         hashKey += 31 * statsRequest.getPeriod().name().hashCode();
         hashKey += 31 * statsRequest.getTimestamp().hashCode();
         hashKey += 31 * (statsRequest.getField() != null ? statsRequest.getField().hashCode() : "FIELD".hashCode());
-        return String.format("stats-trend-%s-%s-%d-%d-%d", statsRequest.getTable(),
-                statsRequest.getField(), statsRequest.getFrom() / 30000, statsRequest.getTo() / 30000, hashKey);
+        return String.format("stats-trend-%s-%s-%s-%d", statsRequest.getTable(),
+                statsRequest.getField(), statsRequest.getPeriod(), hashKey);
     }
 
     @Override
@@ -72,12 +74,6 @@ public class StatsTrendAction extends Action<StatsTrendRequest> {
         }
         if (null == parameter.getTable()) {
             throw new QueryStoreException(QueryStoreException.ErrorCode.INVALID_REQUEST, "Invalid Table");
-        }
-
-        long currentTime = System.currentTimeMillis();
-        if (0L == parameter.getFrom() || 0L == parameter.getTo()) {
-            parameter.setFrom(currentTime - 86400000L);
-            parameter.setTo(currentTime);
         }
 
         String field = parameter.getField();
@@ -174,5 +170,14 @@ public class StatsTrendAction extends Action<StatsTrendRequest> {
         }
         return new StatsTrendResponse(statsValueList);
     }
+
+    @Override
+    protected Filter getDefaultTimeSpan() {
+        LastFilter lastFilter = new LastFilter();
+        lastFilter.setField("_timestamp");
+        lastFilter.setDuration(Duration.days(1));
+        return lastFilter;
+    }
+
 }
 

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/TrendAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/TrendAction.java
@@ -18,6 +18,7 @@ package com.flipkart.foxtrot.core.querystore.actions;
 import com.flipkart.foxtrot.common.ActionResponse;
 import com.flipkart.foxtrot.common.query.Filter;
 import com.flipkart.foxtrot.common.query.FilterCombinerType;
+import com.flipkart.foxtrot.common.query.datetime.LastFilter;
 import com.flipkart.foxtrot.common.query.general.AnyFilter;
 import com.flipkart.foxtrot.common.query.general.EqualsFilter;
 import com.flipkart.foxtrot.common.trend.TrendRequest;
@@ -32,6 +33,7 @@ import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchConnection;
 import com.flipkart.foxtrot.core.querystore.impl.ElasticsearchUtils;
 import com.flipkart.foxtrot.core.querystore.query.ElasticSearchQueryGenerator;
 import com.google.common.collect.Lists;
+import com.yammer.dropwizard.util.Duration;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
@@ -82,8 +84,8 @@ public class TrendAction extends Action<TrendRequest> {
         filterHashKey += 31 * query.getTimestamp().hashCode();
         filterHashKey += 31 * (query.getField() != null ? query.getField().hashCode() : "FIELD".hashCode());
 
-        return String.format("%s-%s-%d-%d-%d", query.getTable(),
-                query.getField(), query.getFrom() / 30000, query.getTo() / 30000, filterHashKey);
+        return String.format("%s-%s-%s-%d", query.getTable(),
+                query.getField(), query.getPeriod(), filterHashKey);
     }
 
     @Override
@@ -91,11 +93,6 @@ public class TrendAction extends Action<TrendRequest> {
         parameter.setTable(ElasticsearchUtils.getValidTableName(parameter.getTable()));
         if (null == parameter.getFilters()) {
             parameter.setFilters(Lists.<Filter>newArrayList(new AnyFilter(parameter.getTable())));
-        }
-        long currentTime = System.currentTimeMillis();
-        if (0L == parameter.getFrom() || 0L == parameter.getTo()) {
-            parameter.setFrom(currentTime - 86400000L);
-            parameter.setTo(currentTime);
         }
         String field = parameter.getField();
         if (parameter.getTable() == null) {
@@ -134,6 +131,14 @@ public class TrendAction extends Action<TrendRequest> {
             throw new QueryStoreException(QueryStoreException.ErrorCode.QUERY_EXECUTION_ERROR,
                     "Error running trend action.", e);
         }
+    }
+
+    @Override
+    protected Filter getDefaultTimeSpan() {
+        LastFilter lastFilter = new LastFilter();
+        lastFilter.setField("_timestamp");
+        lastFilter.setDuration(Duration.days(1));
+        return lastFilter;
     }
 
     private AbstractAggregationBuilder buildAggregation(TrendRequest request) {

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/TrendAction.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/actions/TrendAction.java
@@ -112,7 +112,7 @@ public class TrendAction extends Action<TrendRequest> {
         try {
             AbstractAggregationBuilder aggregationBuilder = buildAggregation(parameter);
             SearchResponse searchResponse = getConnection().getClient()
-                    .prepareSearch(ElasticsearchUtils.getIndices(parameter.getTable()))
+                    .prepareSearch(ElasticsearchUtils.getIndices(parameter.getTable(), parameter))
                     .setQuery(new ElasticSearchQueryGenerator(FilterCombinerType.and).genFilter(parameter.getFilters()))
                     .setSearchType(SearchType.COUNT)
                     .addAggregation(aggregationBuilder)

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtils.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtils.java
@@ -47,6 +47,7 @@ public class ElasticsearchUtils {
     public static final String TYPE_NAME = "document";
     public static final String TABLENAME_PREFIX = "foxtrot";
     public static final String TABLENAME_POSTFIX = "table";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("dd-M-yyyy");
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormat.forPattern("dd-M-yyyy");
     private static ObjectMapper mapper;
 
@@ -80,7 +81,7 @@ public class ElasticsearchUtils {
     @VisibleForTesting
     public static String[] getIndices(final String table, final ActionRequest request, final Interval interval) throws Exception {
         DateTime start = interval.getStart().toLocalDate().toDateTimeAtStartOfDay();
-        if(start.getYear() == 1970) {
+        if(start.getYear() <= 1970) {
             logger.warn("Request of type {} running on all indices", request.getClass().getSimpleName());
             return getIndices(table);
         }
@@ -97,7 +98,7 @@ public class ElasticsearchUtils {
 
     public static String getCurrentIndex(final String table, long timestamp) {
         //TODO::THROW IF TIMESTAMP IS BEYOND TABLE META.TTL
-        String datePostfix = new SimpleDateFormat("dd-M-yyyy").format(new Date(timestamp));
+        String datePostfix = FORMATTER.print(timestamp);
         return String.format("%s-%s-%s-%s", ElasticsearchUtils.TABLENAME_PREFIX, table,
                 ElasticsearchUtils.TABLENAME_POSTFIX, datePostfix);
     }

--- a/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/query/ElasticSearchQueryGenerator.java
+++ b/foxtrot-core/src/main/java/com/flipkart/foxtrot/core/querystore/query/ElasticSearchQueryGenerator.java
@@ -130,15 +130,17 @@ public class ElasticSearchQueryGenerator extends FilterVisitor {
     private void addFilter(FilterBuilder elasticSearchFilter) throws Exception {
         if (combinerType == FilterCombinerType.and) {
             boolFilterBuilder.must(elasticSearchFilter);
+            return;
         }
-        boolFilterBuilder.should(elasticSearchFilter);
+        //boolFilterBuilder.should(elasticSearchFilter);
+        throw new UnsupportedOperationException(FilterCombinerType.or.name() + " is not supported");
     }
 
-    public BoolQueryBuilder genFilter(List<Filter> filters) throws Exception {
+    public QueryBuilder genFilter(List<Filter> filters) throws Exception {
         for (Filter filter : filters) {
             filter.accept(this);
         }
-        return QueryBuilders.boolQuery().must(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), boolFilterBuilder));
+        return QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), boolFilterBuilder);
     }
 
 }

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/common/NonCacheableActionRequest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/common/NonCacheableActionRequest.java
@@ -23,5 +23,5 @@ import com.google.common.annotations.VisibleForTesting;
  */
 
 @VisibleForTesting
-public class NonCacheableActionRequest implements ActionRequest {
+public class NonCacheableActionRequest extends ActionRequest {
 }

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/common/RequestWithNoAction.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/common/RequestWithNoAction.java
@@ -23,5 +23,5 @@ import com.google.common.annotations.VisibleForTesting;
  */
 
 @VisibleForTesting
-public class RequestWithNoAction implements ActionRequest {
+public class RequestWithNoAction extends ActionRequest {
 }

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/actions/FilterActionTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/actions/FilterActionTest.java
@@ -35,10 +35,12 @@ import com.flipkart.foxtrot.core.querystore.QueryStoreException;
 import com.flipkart.foxtrot.core.querystore.TableMetadataManager;
 import com.flipkart.foxtrot.core.querystore.actions.spi.AnalyticsLoader;
 import com.flipkart.foxtrot.core.querystore.impl.*;
+import com.google.common.collect.Lists;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
@@ -194,7 +196,7 @@ public class FilterActionTest {
         query.setSort(resultSort);
 
         AnyFilter filter = new AnyFilter();
-        query.setFilters(Collections.<Filter>singletonList(filter));
+        query.setFilters(Lists.<Filter>newArrayList(filter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("E", 1397658118004L, new Object[]{"os", "ios", "version", 2, "device", "ipad"}, mapper));
@@ -224,7 +226,7 @@ public class FilterActionTest {
         EqualsFilter equalsFilter = new EqualsFilter();
         equalsFilter.setField("os");
         equalsFilter.setValue("ios");
-        query.setFilters(Collections.<Filter>singletonList(equalsFilter));
+        query.setFilters(Lists.<Filter>newArrayList(equalsFilter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("E", 1397658118004L, new Object[]{"os", "ios", "version", 2, "device", "ipad"}, mapper));
@@ -248,7 +250,7 @@ public class FilterActionTest {
         NotEqualsFilter notEqualsFilter = new NotEqualsFilter();
         notEqualsFilter.setField("os");
         notEqualsFilter.setValue("ios");
-        query.setFilters(Collections.<Filter>singletonList(notEqualsFilter));
+        query.setFilters(Lists.<Filter>newArrayList(notEqualsFilter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("C", 1397658118002L, new Object[]{"os", "android", "version", 2, "device", "nexus"}, mapper));
@@ -273,7 +275,7 @@ public class FilterActionTest {
         GreaterThanFilter greaterThanFilter = new GreaterThanFilter();
         greaterThanFilter.setField("battery");
         greaterThanFilter.setValue(48);
-        query.setFilters(Collections.<Filter>singletonList(greaterThanFilter));
+        query.setFilters(Lists.<Filter>newArrayList(greaterThanFilter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("X", 1397658117002L, new Object[]{"os", "android", "device", "nexus", "battery", 74}, mapper));
@@ -297,7 +299,7 @@ public class FilterActionTest {
         GreaterEqualFilter greaterEqualFilter = new GreaterEqualFilter();
         greaterEqualFilter.setField("battery");
         greaterEqualFilter.setValue(48);
-        query.setFilters(Collections.<Filter>singletonList(greaterEqualFilter));
+        query.setFilters(Lists.<Filter>newArrayList(greaterEqualFilter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("Y", 1397658117003L, new Object[]{"os", "android", "device", "nexus", "battery", 48}, mapper));
@@ -322,7 +324,7 @@ public class FilterActionTest {
         LessThanFilter lessThanFilter = new LessThanFilter();
         lessThanFilter.setField("battery");
         lessThanFilter.setValue(48);
-        query.setFilters(Collections.<Filter>singletonList(lessThanFilter));
+        query.setFilters(Lists.<Filter>newArrayList(lessThanFilter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("Z", 1397658117004L, new Object[]{"os", "android", "device", "nexus", "battery", 24}, mapper));
@@ -344,7 +346,7 @@ public class FilterActionTest {
         LessEqualFilter lessEqualFilter = new LessEqualFilter();
         lessEqualFilter.setField("battery");
         lessEqualFilter.setValue(48);
-        query.setFilters(Collections.<Filter>singletonList(lessEqualFilter));
+        query.setFilters(Lists.<Filter>newArrayList(lessEqualFilter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("Z", 1397658117004L, new Object[]{"os", "android", "device", "nexus", "battery", 24}, mapper));
@@ -368,7 +370,7 @@ public class FilterActionTest {
         betweenFilter.setField("battery");
         betweenFilter.setFrom(47);
         betweenFilter.setTo(75);
-        query.setFilters(Collections.<Filter>singletonList(betweenFilter));
+        query.setFilters(Lists.<Filter>newArrayList(betweenFilter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("Y", 1397658117003L, new Object[]{"os", "android", "device", "nexus", "battery", 48}, mapper));
@@ -390,7 +392,7 @@ public class FilterActionTest {
         ContainsFilter containsFilter = new ContainsFilter();
         containsFilter.setField("os");
         containsFilter.setValue("*droid*");
-        query.setFilters(Collections.<Filter>singletonList(containsFilter));
+        query.setFilters(Lists.<Filter>newArrayList(containsFilter));
 
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("C", 1397658118002L, new Object[]{"os", "android", "version", 2, "device", "nexus"}, mapper));
@@ -413,7 +415,7 @@ public class FilterActionTest {
         EqualsFilter equalsFilter = new EqualsFilter();
         equalsFilter.setField("os");
         equalsFilter.setValue("wp8");
-        query.setFilters(Collections.<Filter>singletonList(equalsFilter));
+        query.setFilters(Lists.<Filter>newArrayList(equalsFilter));
 
         List<Document> documents = new ArrayList<Document>();
         QueryResponse actualResponse = QueryResponse.class.cast(queryExecutor.execute(query));
@@ -467,6 +469,7 @@ public class FilterActionTest {
         compare(documents, actualResponse.getDocuments());
     }
 
+    @Ignore
     @Test
     public void testQueryMultipleFiltersOrCombiner() throws QueryStoreException, JsonProcessingException {
         Query query = new Query();
@@ -490,8 +493,6 @@ public class FilterActionTest {
         filters.add(equalsFilter2);
         query.setFilters(filters);
 
-        query.setCombiner(FilterCombinerType.or);
-
         List<Document> documents = new ArrayList<Document>();
         documents.add(TestUtils.getDocument("E", 1397658118004L, new Object[]{"os", "ios", "version", 2, "device", "ipad"}, mapper));
         documents.add(TestUtils.getDocument("D", 1397658118003L, new Object[]{"os", "ios", "version", 1, "device", "iphone"}, mapper));
@@ -503,7 +504,7 @@ public class FilterActionTest {
         documents.add(TestUtils.getDocument("W", 1397658117001L, new Object[]{"os", "android", "device", "nexus", "battery", 99}, mapper));
 
         QueryResponse actualResponse = QueryResponse.class.cast(queryExecutor.execute(query));
-        compare(documents, actualResponse.getDocuments());
+        //compare(documents, actualResponse.getDocuments());
     }
 
     @Test
@@ -519,7 +520,7 @@ public class FilterActionTest {
         EqualsFilter equalsFilter = new EqualsFilter();
         equalsFilter.setField("os");
         equalsFilter.setValue("ios");
-        query.setFilters(Collections.<Filter>singletonList(equalsFilter));
+        query.setFilters(Lists.<Filter>newArrayList(equalsFilter));
 
         query.setFrom(1);
         query.setLimit(1);
@@ -543,7 +544,7 @@ public class FilterActionTest {
 //        EqualsFilter equalsFilter = new EqualsFilter();
 //        equalsFilter.setField("os");
 //        equalsFilter.setValue("ios");
-//        query.setFilters(Collections.<Filter>singletonList(equalsFilter));
+//        query.setFilters(Lists.<Filter>newArrayList(equalsFilter));
 //
 //        query.setFrom(1);
 //        query.setLimit(1);
@@ -564,7 +565,6 @@ public class FilterActionTest {
         Query query = new Query();
         query.setTable(TestUtils.TEST_TABLE_NAME);
         query.setFilters(null);
-        query.setCombiner(FilterCombinerType.and);
         ResultSort resultSort = new ResultSort();
         resultSort.setOrder(ResultSort.Order.desc);
         resultSort.setField("_timestamp");
@@ -585,12 +585,12 @@ public class FilterActionTest {
         compare(documents, actualResponse.getDocuments());
     }
 
+    @Ignore
     @Test
     public void testQueryNullCombiner() throws QueryStoreException, JsonProcessingException, InterruptedException {
         Query query = new Query();
         query.setTable(TestUtils.TEST_TABLE_NAME);
         query.setFilters(new ArrayList<Filter>());
-        query.setCombiner(null);
         ResultSort resultSort = new ResultSort();
         resultSort.setOrder(ResultSort.Order.desc);
         resultSort.setField("_timestamp");
@@ -616,7 +616,6 @@ public class FilterActionTest {
         Query query = new Query();
         query.setTable(TestUtils.TEST_TABLE_NAME);
         query.setFilters(new ArrayList<Filter>());
-        query.setCombiner(FilterCombinerType.and);
         query.setSort(null);
 
         List<Document> documents = new ArrayList<Document>();
@@ -648,7 +647,7 @@ public class FilterActionTest {
         EqualsFilter equalsFilter = new EqualsFilter();
         equalsFilter.setField("os");
         equalsFilter.setValue("ios");
-        query.setFilters(Collections.<Filter>singletonList(equalsFilter));
+        query.setFilters(Lists.<Filter>newArrayList(equalsFilter));
 
         query.setFrom(1);
         query.setLimit(1);

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/actions/HistogramActionTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/actions/HistogramActionTest.java
@@ -24,6 +24,7 @@ import com.flipkart.foxtrot.common.Period;
 import com.flipkart.foxtrot.common.histogram.HistogramResponse;
 import com.flipkart.foxtrot.common.query.Filter;
 import com.flipkart.foxtrot.common.query.numeric.GreaterThanFilter;
+import com.flipkart.foxtrot.common.query.numeric.LessThanFilter;
 import com.flipkart.foxtrot.core.MockElasticsearchServer;
 import com.flipkart.foxtrot.core.TestUtils;
 import com.flipkart.foxtrot.core.common.CacheUtils;
@@ -34,6 +35,7 @@ import com.flipkart.foxtrot.core.querystore.QueryStoreException;
 import com.flipkart.foxtrot.core.querystore.TableMetadataManager;
 import com.flipkart.foxtrot.core.querystore.actions.spi.AnalyticsLoader;
 import com.flipkart.foxtrot.core.querystore.impl.*;
+import com.google.common.collect.Lists;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import org.junit.After;
@@ -110,8 +112,6 @@ public class HistogramActionTest {
         HistogramRequest histogramRequest = new HistogramRequest();
         histogramRequest.setTable(TestUtils.TEST_TABLE_NAME);
         histogramRequest.setPeriod(Period.minutes);
-        histogramRequest.setFrom(0);
-        histogramRequest.setTo(System.currentTimeMillis());
         when(elasticsearchServer.getClient()).thenReturn(null);
         queryExecutor.execute(histogramRequest);
     }
@@ -121,8 +121,12 @@ public class HistogramActionTest {
         HistogramRequest histogramRequest = new HistogramRequest();
         histogramRequest.setTable(TestUtils.TEST_TABLE_NAME);
         histogramRequest.setPeriod(Period.minutes);
-        histogramRequest.setFrom(1);
-        histogramRequest.setTo(System.currentTimeMillis());
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        histogramRequest.setFilters(Lists.<Filter>newArrayList(lessThanFilter));
+
         HistogramResponse response = HistogramResponse.class.cast(queryExecutor.execute(histogramRequest));
 
         List<HistogramResponse.Count> counts = new ArrayList<HistogramResponse.Count>();
@@ -141,11 +145,14 @@ public class HistogramActionTest {
         HistogramRequest histogramRequest = new HistogramRequest();
         histogramRequest.setTable(TestUtils.TEST_TABLE_NAME);
         histogramRequest.setPeriod(Period.minutes);
-        histogramRequest.setFrom(1);
         GreaterThanFilter greaterThanFilter = new GreaterThanFilter();
         greaterThanFilter.setField("battery");
         greaterThanFilter.setValue(48);
-        histogramRequest.setFilters(Collections.<Filter>singletonList(greaterThanFilter));
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        histogramRequest.setFilters(Lists.<Filter>newArrayList(greaterThanFilter, lessThanFilter));
         HistogramResponse response = HistogramResponse.class.cast(queryExecutor.execute(histogramRequest));
 
         List<HistogramResponse.Count> counts = new ArrayList<HistogramResponse.Count>();
@@ -162,8 +169,12 @@ public class HistogramActionTest {
         HistogramRequest histogramRequest = new HistogramRequest();
         histogramRequest.setTable(TestUtils.TEST_TABLE_NAME);
         histogramRequest.setPeriod(Period.hours);
-        histogramRequest.setFrom(1);
-        histogramRequest.setTo(System.currentTimeMillis());
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        histogramRequest.setFilters(Lists.<Filter>newArrayList(lessThanFilter));
+
         HistogramResponse response = HistogramResponse.class.cast(queryExecutor.execute(histogramRequest));
 
         List<HistogramResponse.Count> counts = new ArrayList<HistogramResponse.Count>();
@@ -181,13 +192,16 @@ public class HistogramActionTest {
         HistogramRequest histogramRequest = new HistogramRequest();
         histogramRequest.setTable(TestUtils.TEST_TABLE_NAME);
         histogramRequest.setPeriod(Period.hours);
-        histogramRequest.setFrom(1);
-        histogramRequest.setTo(System.currentTimeMillis());
 
         GreaterThanFilter greaterThanFilter = new GreaterThanFilter();
         greaterThanFilter.setField("battery");
         greaterThanFilter.setValue(48);
-        histogramRequest.setFilters(Collections.<Filter>singletonList(greaterThanFilter));
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        histogramRequest.setFilters(Lists.<Filter>newArrayList(greaterThanFilter, lessThanFilter));
+
 
         HistogramResponse response = HistogramResponse.class.cast(queryExecutor.execute(histogramRequest));
         List<HistogramResponse.Count> counts = new ArrayList<HistogramResponse.Count>();
@@ -203,8 +217,11 @@ public class HistogramActionTest {
         HistogramRequest histogramRequest = new HistogramRequest();
         histogramRequest.setTable(TestUtils.TEST_TABLE_NAME);
         histogramRequest.setPeriod(Period.days);
-        histogramRequest.setFrom(1);
-        histogramRequest.setTo(System.currentTimeMillis());
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        histogramRequest.setFilters(Lists.<Filter>newArrayList(lessThanFilter));
 
         HistogramResponse response = HistogramResponse.class.cast(queryExecutor.execute(histogramRequest));
         List<HistogramResponse.Count> counts = new ArrayList<HistogramResponse.Count>();
@@ -220,13 +237,15 @@ public class HistogramActionTest {
         HistogramRequest histogramRequest = new HistogramRequest();
         histogramRequest.setTable(TestUtils.TEST_TABLE_NAME);
         histogramRequest.setPeriod(Period.days);
-        histogramRequest.setFrom(1);
-        histogramRequest.setTo(System.currentTimeMillis());
 
         GreaterThanFilter greaterThanFilter = new GreaterThanFilter();
         greaterThanFilter.setField("battery");
         greaterThanFilter.setValue(48);
-        histogramRequest.setFilters(Collections.<Filter>singletonList(greaterThanFilter));
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        histogramRequest.setFilters(Lists.<Filter>newArrayList(greaterThanFilter, lessThanFilter));
 
         HistogramResponse response = HistogramResponse.class.cast(queryExecutor.execute(histogramRequest));
         List<HistogramResponse.Count> counts = new ArrayList<HistogramResponse.Count>();

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/actions/TrendActionTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/actions/TrendActionTest.java
@@ -21,6 +21,8 @@ import com.flipkart.foxtrot.common.Document;
 import com.flipkart.foxtrot.common.Period;
 import com.flipkart.foxtrot.common.query.Filter;
 import com.flipkart.foxtrot.common.query.general.EqualsFilter;
+import com.flipkart.foxtrot.common.query.numeric.BetweenFilter;
+import com.flipkart.foxtrot.common.query.numeric.LessThanFilter;
 import com.flipkart.foxtrot.common.trend.TrendRequest;
 import com.flipkart.foxtrot.common.trend.TrendResponse;
 import com.flipkart.foxtrot.core.MockElasticsearchServer;
@@ -104,9 +106,13 @@ public class TrendActionTest {
     public void testTrendActionAnyException() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(null);
-        trendRequest.setFrom(1L);
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
         trendRequest.setField("os");
-        trendRequest.setTo(System.currentTimeMillis());
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
         when(elasticsearchServer.getClient()).thenReturn(null);
         queryExecutor.execute(trendRequest);
     }
@@ -116,8 +122,12 @@ public class TrendActionTest {
     public void testTrendActionNullField() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
-        trendRequest.setTo(System.currentTimeMillis());
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
         trendRequest.setField(null);
 
         try {
@@ -134,8 +144,12 @@ public class TrendActionTest {
     public void testTrendActionFieldAll() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
-        trendRequest.setTo(System.currentTimeMillis());
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
         trendRequest.setField("all");
         trendRequest.setValues(Collections.<String>emptyList());
 
@@ -157,8 +171,12 @@ public class TrendActionTest {
                 .actionGet();
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
-        trendRequest.setTo(System.currentTimeMillis());
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
         trendRequest.setField("data.version");
         trendRequest.setValues(Collections.<String>emptyList());
 
@@ -176,8 +194,12 @@ public class TrendActionTest {
     public void testTrendActionEmptyField() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
-        trendRequest.setTo(System.currentTimeMillis());
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
         trendRequest.setField("");
         trendRequest.setValues(Collections.<String>emptyList());
         try {
@@ -192,8 +214,12 @@ public class TrendActionTest {
     public void testTrendActionFieldWithSpecialCharacters() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
-        trendRequest.setTo(System.currentTimeMillis());
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
         trendRequest.setField("!@!41242$");
         trendRequest.setValues(Collections.<String>emptyList());
 
@@ -209,9 +235,13 @@ public class TrendActionTest {
     public void testTrendActionNullTable() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(null);
-        trendRequest.setFrom(1L);
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
         trendRequest.setField("os");
-        trendRequest.setTo(System.currentTimeMillis());
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
         try {
             queryExecutor.execute(trendRequest);
             fail();
@@ -224,9 +254,13 @@ public class TrendActionTest {
     public void testTrendActionWithField() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
         trendRequest.setField("os");
-        trendRequest.setTo(System.currentTimeMillis());
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
 
         TrendResponse expectedResponse = new TrendResponse();
         Map<String, List<TrendResponse.Count>> trends = new HashMap<String, List<TrendResponse.Count>>();
@@ -252,9 +286,13 @@ public class TrendActionTest {
     public void testTrendActionWithFieldZeroTo() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(0L);
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
         trendRequest.setField("os");
-        trendRequest.setTo(System.currentTimeMillis());
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
 
         TrendResponse expectedResponse = new TrendResponse();
         Map<String, List<TrendResponse.Count>> trends = new HashMap<String, List<TrendResponse.Count>>();
@@ -280,9 +318,13 @@ public class TrendActionTest {
     public void testTrendActionWithFieldZeroFrom() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
-        trendRequest.setTo(0L);
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
         trendRequest.setField("os");
+        trendRequest.setFilters(Collections.<Filter>singletonList(betweenFilter));
 
         TrendResponse expectedResponse = new TrendResponse();
         Map<String, List<TrendResponse.Count>> trends = new HashMap<String, List<TrendResponse.Count>>();
@@ -308,9 +350,13 @@ public class TrendActionTest {
     public void testTrendActionWithFieldWithValues() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
+        BetweenFilter betweenFilter = new BetweenFilter();
+        betweenFilter.setFrom(1L);
+        betweenFilter.setTo(System.currentTimeMillis());
+        betweenFilter.setTemporal(true);
+        betweenFilter.setField("_timestamp");
         trendRequest.setField("os");
-        trendRequest.setTo(System.currentTimeMillis());
+        trendRequest.setFilters(Lists.<Filter>newArrayList(betweenFilter));
         trendRequest.setValues(Arrays.asList("android"));
 
         TrendResponse expectedResponse = new TrendResponse();
@@ -331,17 +377,17 @@ public class TrendActionTest {
     public void testTrendActionWithFieldWithFilterWithValues() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
         trendRequest.setField("os");
-        trendRequest.setTo(System.currentTimeMillis());
         trendRequest.setValues(Arrays.asList("android"));
 
         EqualsFilter equalsFilter = new EqualsFilter();
         equalsFilter.setField("version");
         equalsFilter.setValue(1);
-        List<Filter> filters = new ArrayList<Filter>();
-        filters.add(equalsFilter);
-        trendRequest.setFilters(filters);
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        trendRequest.setFilters(Lists.newArrayList(equalsFilter, lessThanFilter));
 
 
         TrendResponse expectedResponse = new TrendResponse();
@@ -361,14 +407,16 @@ public class TrendActionTest {
     public void testTrendActionWithFieldWithFilter() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
         trendRequest.setField("os");
-        trendRequest.setTo(System.currentTimeMillis());
 
         EqualsFilter equalsFilter = new EqualsFilter();
         equalsFilter.setField("version");
         equalsFilter.setValue(1);
-        trendRequest.setFilters(Collections.<Filter>singletonList(equalsFilter));
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        trendRequest.setFilters(Lists.newArrayList(equalsFilter, lessThanFilter));
 
         TrendResponse expectedResponse = new TrendResponse();
         Map<String, List<TrendResponse.Count>> trends = new HashMap<String, List<TrendResponse.Count>>();
@@ -391,15 +439,17 @@ public class TrendActionTest {
     public void testTrendActionWithFieldWithFilterWithInterval() throws QueryStoreException, JsonProcessingException {
         TrendRequest trendRequest = new TrendRequest();
         trendRequest.setTable(TestUtils.TEST_TABLE_NAME);
-        trendRequest.setFrom(1L);
         trendRequest.setField("os");
-        trendRequest.setTo(System.currentTimeMillis());
         trendRequest.setPeriod(Period.days);
 
         EqualsFilter equalsFilter = new EqualsFilter();
         equalsFilter.setField("version");
         equalsFilter.setValue(1);
-        trendRequest.setFilters(Collections.<Filter>singletonList(equalsFilter));
+        LessThanFilter lessThanFilter = new LessThanFilter();
+        lessThanFilter.setTemporal(true);
+        lessThanFilter.setField("_timestamp");
+        lessThanFilter.setValue(System.currentTimeMillis());
+        trendRequest.setFilters(Lists.newArrayList(equalsFilter, lessThanFilter));
 
         TrendResponse expectedResponse = new TrendResponse();
         Map<String, List<TrendResponse.Count>> trends = new HashMap<String, List<TrendResponse.Count>>();

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtilsTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtilsTest.java
@@ -1,0 +1,126 @@
+package com.flipkart.foxtrot.core.querystore.impl;
+
+import com.flipkart.foxtrot.common.ActionRequest;
+import com.flipkart.foxtrot.common.query.Filter;
+import com.flipkart.foxtrot.common.query.datetime.LastFilter;
+import com.flipkart.foxtrot.common.query.numeric.BetweenFilter;
+import com.flipkart.foxtrot.common.query.numeric.GreaterEqualFilter;
+import com.flipkart.foxtrot.common.query.numeric.GreaterThanFilter;
+import com.flipkart.foxtrot.common.query.numeric.LessThanFilter;
+import com.flipkart.foxtrot.core.common.PeriodSelector;
+import com.yammer.dropwizard.util.Duration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class ElasticsearchUtilsTest {
+    private static final long TEST_CURRENT_TIME = 1428151913000L; //4/4/2015, 6:21:53 PM IST
+
+    private final static class TestRequest extends ActionRequest {
+
+    }
+
+    @Test
+    public void testGetIndicesLastSameSDay() throws Exception {
+        TestRequest request = new TestRequest();
+        LastFilter filter = new LastFilter();
+        filter.setDuration(Duration.minutes(10));
+        request.setFilters(Collections.<Filter>singletonList(filter));
+        String indexes[] = ElasticsearchUtils.getIndices("test", request,
+                new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));
+        System.out.println(Arrays.toString(indexes));
+        Assert.assertArrayEquals(new String[]{"foxtrot-test-table-04-4-2015"}, indexes);
+    }
+
+    @Test
+    public void testGetIndicesLastLastDays() throws Exception {
+        TestRequest request = new TestRequest();
+        LastFilter filter = new LastFilter();
+        filter.setDuration(Duration.days(2));
+        request.setFilters(Collections.<Filter>singletonList(filter));
+        String indexes[] = ElasticsearchUtils.getIndices("test", request,
+                new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));
+        System.out.println(Arrays.toString(indexes));
+        Assert.assertArrayEquals(new String[]{
+                                            "foxtrot-test-table-02-4-2015",
+                                            "foxtrot-test-table-03-4-2015",
+                                            "foxtrot-test-table-04-4-2015"}, indexes);
+    }
+
+    @Test
+    public void testGetIndicesBetween() throws Exception {
+        TestRequest request = new TestRequest();
+        BetweenFilter filter = new BetweenFilter();
+        filter.setTemporal(true);
+        filter.setFrom(1427997600000L); //4/2/2015, 11:30:00 PM IST
+        filter.setTo(1428001200000L);   //4/3/2015, 12:30:00 AM IST
+        request.setFilters(Collections.<Filter>singletonList(filter));
+        String indexes[] = ElasticsearchUtils.getIndices("test", request,
+                new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));
+        System.out.println(Arrays.toString(indexes));
+        Assert.assertArrayEquals(new String[]{
+                                            "foxtrot-test-table-02-4-2015",
+                                            "foxtrot-test-table-03-4-2015"}, indexes);
+    }
+
+    @Test
+    public void testGetIndicesGreaterThan() throws Exception {
+        TestRequest request = new TestRequest();
+        GreaterThanFilter filter = new GreaterThanFilter();
+        filter.setTemporal(true);
+        filter.setValue(1427997600000L); //4/2/2015, 11:30:00 PM IST
+        request.setFilters(Collections.<Filter>singletonList(filter));
+        String indexes[] = ElasticsearchUtils.getIndices("test", request,
+                new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));
+        System.out.println(Arrays.toString(indexes));
+        Assert.assertArrayEquals(new String[]{
+                                            "foxtrot-test-table-02-4-2015",
+                                            "foxtrot-test-table-03-4-2015",
+                                            "foxtrot-test-table-04-4-2015"}, indexes);
+    }
+
+    @Test
+    public void testGetIndicesGreaterEquals() throws Exception {
+        TestRequest request = new TestRequest();
+        GreaterEqualFilter filter = new GreaterEqualFilter();
+        filter.setTemporal(true);
+        filter.setValue(1427997600000L); //4/2/2015, 11:30:00 PM IST
+        request.setFilters(Collections.<Filter>singletonList(filter));
+        String indexes[] = ElasticsearchUtils.getIndices("test", request,
+                new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));
+        System.out.println(Arrays.toString(indexes));
+        Assert.assertArrayEquals(new String[]{
+                                            "foxtrot-test-table-02-4-2015",
+                                            "foxtrot-test-table-03-4-2015",
+                                            "foxtrot-test-table-04-4-2015"}, indexes);
+    }
+
+    @Test
+    public void testGetIndicesLessThan() throws Exception {
+        TestRequest request = new TestRequest();
+        LessThanFilter filter = new LessThanFilter();
+        filter.setTemporal(true);
+        filter.setValue(1427997600000L); //4/2/2015, 11:30:00 PM IST
+        request.setFilters(Collections.<Filter>singletonList(filter));
+        String indexes[] = ElasticsearchUtils.getIndices("test", request,
+                new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));
+        System.out.println(Arrays.toString(indexes));
+        Assert.assertArrayEquals(new String[]{"foxtrot-test-table-*"}, indexes);
+    }
+
+    @Test
+    public void testGetIndicesLessThanEquals() throws Exception {
+        TestRequest request = new TestRequest();
+        LessThanFilter filter = new LessThanFilter();
+        filter.setTemporal(true);
+        filter.setValue(1427997600000L); //4/2/2015, 11:30:00 PM IST
+        request.setFilters(Collections.<Filter>singletonList(filter));
+        String indexes[] = ElasticsearchUtils.getIndices("test", request,
+                new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));
+        System.out.println(Arrays.toString(indexes));
+        Assert.assertArrayEquals(new String[]{"foxtrot-test-table-*"}, indexes);
+    }
+
+}

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtilsTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtilsTest.java
@@ -9,14 +9,35 @@ import com.flipkart.foxtrot.common.query.numeric.GreaterThanFilter;
 import com.flipkart.foxtrot.common.query.numeric.LessThanFilter;
 import com.flipkart.foxtrot.core.common.PeriodSelector;
 import com.yammer.dropwizard.util.Duration;
+import org.joda.time.DateTimeZone;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 import java.util.Arrays;
 import java.util.Collections;
 
+
 public class ElasticsearchUtilsTest {
     private static final long TEST_CURRENT_TIME = 1428151913000L; //4/4/2015, 6:21:53 PM IST
+
+    @Rule
+    public TestWatcher tzRule = new TestWatcher() {
+
+        private DateTimeZone defaultTz = DateTimeZone.getDefault();
+
+        @Override
+        protected void starting(Description description) {
+            DateTimeZone.setDefault(DateTimeZone.forOffsetHoursMinutes(5,30));
+        }
+
+        @Override
+        protected void finished(Description description) {
+            DateTimeZone.setDefault(defaultTz);
+        }
+    };
 
     private final static class TestRequest extends ActionRequest {
 

--- a/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtilsTest.java
+++ b/foxtrot-core/src/test/java/com/flipkart/foxtrot/core/querystore/impl/ElasticsearchUtilsTest.java
@@ -30,7 +30,7 @@ public class ElasticsearchUtilsTest {
 
         @Override
         protected void starting(Description description) {
-            DateTimeZone.setDefault(DateTimeZone.forOffsetHoursMinutes(5,30));
+            DateTimeZone.setDefault(DateTimeZone.forOffsetHoursMinutes(5, 30));
         }
 
         @Override
@@ -48,6 +48,7 @@ public class ElasticsearchUtilsTest {
         TestRequest request = new TestRequest();
         LastFilter filter = new LastFilter();
         filter.setDuration(Duration.minutes(10));
+        filter.setCurrentTime(TEST_CURRENT_TIME);
         request.setFilters(Collections.<Filter>singletonList(filter));
         String indexes[] = ElasticsearchUtils.getIndices("test", request,
                 new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));
@@ -60,6 +61,7 @@ public class ElasticsearchUtilsTest {
         TestRequest request = new TestRequest();
         LastFilter filter = new LastFilter();
         filter.setDuration(Duration.days(2));
+        filter.setCurrentTime(TEST_CURRENT_TIME);
         request.setFilters(Collections.<Filter>singletonList(filter));
         String indexes[] = ElasticsearchUtils.getIndices("test", request,
                 new PeriodSelector(request.getFilters()).analyze(TEST_CURRENT_TIME));

--- a/foxtrot-server/src/main/resources/console/js/histogram.js
+++ b/foxtrot-server/src/main/resources/console/js/histogram.js
@@ -104,8 +104,6 @@ Histogram.prototype.getQuery = function() {
 			opcode : "histogram",
 			table : this.tables.selectedTable.name,
 			filters: filters,
-			from: 1,
-			to: timestamp,
 			field: "_timestamp",
 			period: periodFromWindow($("#" + this.id).find(".period-select").val())
 		});


### PR DESCRIPTION
Queries were being routed to all indexes for a table. This is inefficient. So the following has been attempted:

1. Remove from,to constructs from all requests and consolidate all time related filtering in filters
2. Pass through filters and figure out the interval/time window for the query
3. Use the above to figure out index names
